### PR TITLE
Replace external IP provider

### DIFF
--- a/certbot_dns_namecheap/dns_namecheap.py
+++ b/certbot_dns_namecheap/dns_namecheap.py
@@ -78,7 +78,7 @@ class _NamecheapLexiconClient(dns_common_lexicon.LexiconClient):
 
     def __init__(self, username, api_key, ttl, domain):
         super(_NamecheapLexiconClient, self).__init__()
-        my_ip = urlopen('http://ip.42.pl/raw').read()
+        my_ip = urlopen('https://icanhazip.com').read()
         logger.debug(my_ip)
         self.provider = ncProvider({
             'auth_username': username,


### PR DESCRIPTION
This plugin relies on an external service to determine the IP of the local machine (https://ip.42.pl/raw), which is classified as a malicious address:
https://otx.alienvault.com/indicator/domain/ip.42.pl

Aside from that, 42.pl isn't resolving anymore which makes the whole plugin crash. I replaced it with the provider icanhazip.com which made the plugin run again on my machine.